### PR TITLE
update: switch to modern twitter embed link

### DIFF
--- a/cogs/embedfix/__init__.py
+++ b/cogs/embedfix/__init__.py
@@ -38,8 +38,8 @@ PLATFORM_FIXES = {
             r"https?://(?:www\.)?x\.com/\w+/status/\d+",
         ],
         "replacements": [
-            ("twitter.com", "vxtwitter.com"),
-            ("x.com", "vxtwitter.com"),
+            ("twitter.com", "fxtwitter.com"),
+            ("x.com", "fxtwitter.com"),
         ],
     },
 }


### PR DESCRIPTION
VXTwitterではエンゲージメントなどの情報が出ないため、FXTwitterに変更する。